### PR TITLE
Fixes #2 overriding of cq dialog tabs not working anymore with latest AEM

### DIFF
--- a/src/main/content/jcr_root/apps/demos/components/page/_cq_dialog/.content.xml
+++ b/src/main/content/jcr_root/apps/demos/components/page/_cq_dialog/.content.xml
@@ -1,33 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="nt:unstructured">
     <content jcr:primaryType="nt:unstructured">
         <items jcr:primaryType="nt:unstructured">
             <tabs jcr:primaryType="nt:unstructured">
                 <items jcr:primaryType="nt:unstructured">
-                    <basic jcr:primaryType="nt:unstructured">
-                        <items jcr:primaryType="nt:unstructured">
-                            <column jcr:primaryType="nt:unstructured">
-                                <items jcr:primaryType="nt:unstructured">
-                                    <title jcr:primaryType="nt:unstructured">
-                                        <items jcr:primaryType="nt:unstructured">
-                                            <title
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:orderBefore="pagename"
-                                                fieldLabel="Title (in first position!)"
-                                                allowBulkEdit="true"/>
-                                        </items>
-                                    </title>
-                                    <moretitles
-                                        cq:showOnCreate="{Boolean}false"
-                                        jcr:primaryType="nt:unstructured"/>
-                                </items>
-                            </column>
-                        </items>
-                    </basic>
-                    <advanced
-                        cq:showOnCreate="{Boolean}false"
-                        jcr:primaryType="nt:unstructured"/>
+                    <basic
+                        jcr:primaryType="nt:unstructured"
+                        path="/mnt/override/apps/demos/components/page/tabs/basic"/>
                 </items>
             </tabs>
         </items>

--- a/src/main/content/jcr_root/apps/demos/components/page/_cq_dialog/.content.xml
+++ b/src/main/content/jcr_root/apps/demos/components/page/_cq_dialog/.content.xml
@@ -8,6 +8,9 @@
                     <basic
                         jcr:primaryType="nt:unstructured"
                         path="/mnt/override/apps/demos/components/page/tabs/basic"/>
+                    <advanced
+                        jcr:primaryType="nt:unstructured"
+                        path="/mnt/override/apps/demos/components/page/tabs/advanced"/>
                 </items>
             </tabs>
         </items>

--- a/src/main/content/jcr_root/apps/demos/components/page/tabs/.content.xml
+++ b/src/main/content/jcr_root/apps/demos/components/page/tabs/.content.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured">
+    <basic jcr:primaryType="nt:unstructured">
+        <items jcr:primaryType="nt:unstructured">
+            <column jcr:primaryType="nt:unstructured">
+                <items jcr:primaryType="nt:unstructured">
+                    <title jcr:primaryType="nt:unstructured">
+                        <items jcr:primaryType="nt:unstructured">
+                            <title
+                                jcr:primaryType="nt:unstructured"
+                                sling:orderBefore="pagename"
+                                allowBulkEdit="true"
+                                fieldLabel="Title (in first position!)"/>
+                        </items>
+                    </title>
+                    <moretitles
+                        cq:showOnCreate="{Boolean}false"
+                        jcr:primaryType="nt:unstructured"/>
+                </items>
+            </column>
+        </items>
+    </basic>
+</jcr:root>

--- a/src/main/content/jcr_root/apps/demos/components/page/tabs/.content.xml
+++ b/src/main/content/jcr_root/apps/demos/components/page/tabs/.content.xml
@@ -21,4 +21,7 @@
             </column>
         </items>
     </basic>
+    <advanced
+        cq:showOnCreate="{Boolean}false"
+        jcr:primaryType="nt:unstructured"/>
 </jcr:root>


### PR DESCRIPTION
applies to:
6.3 SP2 and 6.4 (and above)